### PR TITLE
fix: protect (( )) arithmetic from set -e crashes in VRAM measurement

### DIFF
--- a/llm-server
+++ b/llm-server
@@ -4222,7 +4222,7 @@ if try_start "${MOE_MMAP_FLAGS[@]}" -ot "$OT_STRING"; then
         if [[ ! "$raw_free" =~ ^[0-9]+$ ]]; then
             estimated_used=$(( LAYERS_PER_GPU[$gi] * COST_PER_LAYER_MB ))
             raw_free=$(( GPU_VRAM_FREE[$gi] - estimated_used ))
-            (( raw_free < 0 )) && raw_free=0
+            (( raw_free < 0 )) && raw_free=0 || true
             log "  GPU${GPU_INDEX[$gi]}: nvidia-smi free readback failed, estimating ${raw_free}MB"
         fi
         ACTUAL_FREE[$gi]=$raw_free
@@ -4241,13 +4241,13 @@ if try_start "${MOE_MMAP_FLAGS[@]}" -ot "$OT_STRING"; then
         # Subtract KV cache that will be allocated for layers already on this GPU
         current_kv=$(( LAYERS_PER_GPU[$gi] * KV_PER_LAYER_MB ))
         usable_free=$(( ACTUAL_FREE[$gi] - current_kv - SAFETY_MB ))
-        (( usable_free < 0 )) && usable_free=0
+        (( usable_free < 0 )) && usable_free=0 || true
         if (( COST_PER_LAYER_MB > 0 )); then
             extra=$(( usable_free / COST_PER_LAYER_MB ))
         fi
-        (( extra < 0 )) && extra=0
+        (( extra < 0 )) && extra=0 || true
         EXTRA_PER_GPU[$gi]=$extra
-        (( TOTAL_EXTRA += extra ))
+        (( TOTAL_EXTRA += extra )) || true
     done
 
     # Apply extras (priority order), cap to remaining CPU layers
@@ -4258,7 +4258,7 @@ if try_start "${MOE_MMAP_FLAGS[@]}" -ot "$OT_STRING"; then
             add=$(( EXTRA_PER_GPU[$gi] < remaining_cpu ? EXTRA_PER_GPU[$gi] : remaining_cpu ))
             LAYERS_PER_GPU[$gi]=$(( LAYERS_PER_GPU[$gi] + add ))
             remaining_cpu=$(( remaining_cpu - add ))
-            (( remaining_cpu <= 0 )) && break
+            (( remaining_cpu <= 0 )) && break || true
         done
         LAYERS_CPU=$remaining_cpu
         TOTAL_GPU_LAYERS=$(( LAYER_COUNT - LAYERS_CPU ))


### PR DESCRIPTION
This is the same issue as https://github.com/raketenkater/llm-server/issues/7 so I went ahead and with the help of my clanker (LLM) I made some changes that I believe were leading me to crashes under WSL2:

Under 'set -euo pipefail', any (( expr )) that evaluates to 0 returns exit status 1, which triggers an immediate silent script abort. The following arithmetic expressions were missing '|| true' guards:

    - Line 4225: (( raw_free < 0 )) && raw_free=0
    - Line 4244: (( usable_free < 0 )) && usable_free=0
    - Line 4248: (( extra < 0 )) && extra=0
    - Line 4250: (( TOTAL_EXTRA += extra ))
    - Line 4261: (( remaining_cpu <= 0 )) && break

This caused silent crashes after 'Measuring VRAM headroom...' when nvidia-smi returned 0 or when VRAM was full (extra=0, TOTAL_EXTRA=0), particularly common on WSL2 where nvidia-smi is flaky.

**As mentioned above much of the research here is made by AI as my understanding of bash is limited.**