### PR TITLE
Fix non-Linux scope compatibility

### DIFF
--- a/go/pkg/server/scope_other.go
+++ b/go/pkg/server/scope_other.go
@@ -30,6 +30,12 @@ func resetFailedScopeUnit(string) error { return nil }
 
 func waitScopeUnitStopped(string, time.Duration) error { return nil }
 
+func scopeUnitActive(string) bool { return false }
+
+func scopeControlGroup(string) (string, error) {
+	return "", fmt.Errorf("backend memory scopes are only implemented on Linux/systemd")
+}
+
 func scopeMemoryPeakBytes(string) (uint64, error) {
 	return 0, fmt.Errorf("backend memory scopes are only implemented on Linux/systemd")
 }
@@ -48,5 +54,13 @@ func scopeNonReclaimableMB(string) (int, error) {
 }
 
 func setScopeMemoryMaxMB(string, int) error {
+	return fmt.Errorf("backend memory scopes are only implemented on Linux/systemd")
+}
+
+func (p *Process) ScopeNonReclaimableMB() (int, error) {
+	return 0, fmt.Errorf("backend memory scopes are only implemented on Linux/systemd")
+}
+
+func (p *Process) SetMemoryMaxMB(int) error {
 	return fmt.Errorf("backend memory scopes are only implemented on Linux/systemd")
 }


### PR DESCRIPTION
## Summary

Add fail-closed non-Linux implementations for scope helpers and Process methods that are shared by the cross-platform server code.

Without these stubs, macOS cannot compile because scopeUnitActive, Process.ScopeNonReclaimableMB, and Process.SetMemoryMaxMB are defined only in the Linux systemd file. scopeControlGroup is also required so the Linux-only scope test can compile before its runtime GOOS skip.

The non-Linux implementations do not emulate containment: the active check returns false and cgroup-backed operations return the existing Linux/systemd-only error.

## Checks

- gofmt and git diff --check
- go test ./pkg/server -run TestScopeSetMemoryMaxMBAndNonReclaimable|TestStopScopeUnit -count=1
- go build ./...

## Broader suite note

A full go test ./... was also attempted on macOS. It now compiles past the added scope symbols but retains unrelated existing macOS failures involving /var versus /private/var canonicalization, backend/platform assumptions, reclaim-band expectations, terminal detection, and one captured-log assertion. Those are intentionally outside this focused compatibility patch.